### PR TITLE
Added windows compiling ability to tree-hugger

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,13 @@ _You may need to install libgit2. In case you are in mac just use `brew install 
 
 ## Setup
 
-### Getting your .so files
+### Getting the files
 
 From onwards tree-hugger 0.9 we ship a new command `download_libs`.
 
-If you are working on Debian based Linux or Newer version of MacOS then you should probably just use this command to get the library. At any point of time we will maintain a .so file for both those OSs with all the supported languages in it. 
+If you are working on Debian based Linux or Newer version of MacOS then you should probably just use this command to get the library. At any point of time we will maintain a [.so](https://en.wikipedia.org/wiki/Static_library) file for both those OSs with all the supported languages in it.
+
+If you are working on Windows then you would be getting a [.dll](https://en.wikipedia.org/wiki/Dynamic-link_library) file rather than a .so file.
 
 To get the .so file for your platform you can simply do the following 
 
@@ -99,13 +101,13 @@ optional arguments:
                         Default - my-languages.so
 ```
 
-### Building the .so files
+### Building the files
 
 _Please note that building the libraries has been tested under a macOS Mojave with Apple LLVM version 10.0.1 (clang-1001.0.46.4)_
 
 _Please check out our Linux specific instructions [here](https://github.com/autosoft-dev/tree-sitter-docker)_
 
-Once this library is installed it gives you a command line utility to download and compile tree-sitter .so files with ease. As an example - 
+Once this library is installed it gives you a command line utility to download and compile tree-sitter .so or .dll files (depending upon the OS) with ease. As an example -
 
 ```
 create_libs python

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ tree-sitter==0.2.0
 pygit2==0.28.2
 pytest==5.4.1
 PyYAML==5.3.1
+requests

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ classifiers=[
 ],
 version="0.10.1",
 packages=find_packages(exclude=("tests",)),
-install_requires=["tree-sitter", "pygit2", "pytest", "PyYAML"],
+install_requires=["tree-sitter", "pygit2", "pytest", "PyYAML", "requests"],
 entry_points = {
     'console_scripts': ['create_libs=tree_hugger.cli.create_libs:main',
                         'download_libs=tree_hugger.cli.download_libs:main'],

--- a/tree_hugger/cli/create_libs.py
+++ b/tree_hugger/cli/create_libs.py
@@ -71,6 +71,9 @@ def main():
     args = parser.parse_args()
     repo_arr = []
 
+    if _which_os()=="windows":
+        args.lib_name = args.lib_name.split(".")[0] + ".dll"
+
     max_workers = len(args.langs)
     with ProcessPoolExecutor(max_workers=max_workers) as executor:
         repo_downloaders = {executor.submit(clone_repo, lang_name): lang_name for lang_name in args.langs}

--- a/tree_hugger/cli/download_libs.py
+++ b/tree_hugger/cli/download_libs.py
@@ -1,26 +1,25 @@
 from argparse import ArgumentParser
-
 import logging
-
 import requests
-
 from tree_hugger.exceptions import OSNotSupported
 import tree_hugger.setup_logging
 from tree_hugger.cli.os_detector import _which_os
 
-ALLOWED_OS = ["linux", "darwin"]
-ALLOWED_OS_HUMAN_READABLE = {"linux": "Linux", "darwin": "MacOS"}
+ALLOWED_OS = ["linux", "darwin", "windows"]
+ALLOWED_OS_HUMAN_READABLE = {"linux": "Linux", "darwin": "MacOS", "windows":"Windows"}
 
 is_in_allowed_os = lambda x: x in ALLOWED_OS
 
 LIB_NAME = {"linux": "py_php_js_cpp_java_linux_64.so",
-            "darwin": "py_php_js_cpp_java_darwin_64.so"}
+            "darwin": "py_php_js_cpp_java_darwin_64.so",
+            "windows":"py_php_js_cpp_java_windows_32.dll"}
 
 BASE_URL = "https://tree-hugger-libs.s3.amazonaws.com/"
 
 
 def _download_lib_to_local(os_type, local_file_name):
     url = f"{BASE_URL}{LIB_NAME[os_type]}"
+
     with requests.get(url, stream=True) as r:
         r.raise_for_status()
         block_size = 1024 #1 Kbyte
@@ -37,9 +36,9 @@ def main():
 
     args = paser.parse_args()
 
-    if not is_in_allowed_os(_which_os()):
-        raise OSNotSupported(f"Sorry! Your OS '{_which_os()}' is not supported yet.")
+    if _which_os()=="windows":
+        args.local_file_name = args.local_file_name.split(".")[0] + ".dll"
 
-    logging.info(f"Downloading .so files for '{ALLOWED_OS_HUMAN_READABLE[_which_os()]}' version")
+    logging.info(f"Downloading .{args.local_file_name.split('.')[1]} files for '{ALLOWED_OS_HUMAN_READABLE[_which_os()]}' version")
     _download_lib_to_local(_which_os(), args.local_file_name)
-    logging.info(f".so library saved to {args.local_file_name}.")
+    logging.info(f".{args.local_file_name.split('.')[1]} library saved to {args.local_file_name}.")


### PR DESCRIPTION
Following scripts have been updated - 
- [x] download_libs.py
- [x] create_libs.py

Both of these files belong to the tree_hugger package and hence updation in the module is necessary on PyPI. Until the next version it would be good to run `pip install -e .` to work on windows.

I worked in a virtual environment on Windows and did not get `requests` module pre-installed with it but it is required for the installation and working of the tree-hugger package. If maintainers would agree, I would update the requirements.txt file regarding the installation of `requests` module.

The Windows `.dll` that we are working with is being built using a 32 bit Python Interpretor. Running the same with 64 bit Interpreter abruptly shuts down the current session. This could be possibly due to a data type overflow error. [#18](https://github.com/tree-sitter/py-tree-sitter/issues/18) deals with this issue in detail.